### PR TITLE
server: Making both web ports configurable flags

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -30,7 +30,13 @@ func (s state) TrafficStats() ops.TrafficStats {
 
 func main() {
 	InitLogging()
+
+	var port int
+	var debugPort int
+	flag.IntVar(&port, "port", 80, "Port for the main web server")
+	flag.IntVar(&debugPort, "debug-port", 8080, "Port for the debug web server")
 	flag.Parse()
+
 	config.MustLoadConfig()
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
@@ -54,13 +60,13 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runWebServer(ctx, handlers.CreateRouter(ctx, s), 8008)
+		runWebServer(ctx, handlers.CreateRouter(ctx, s), port)
 	}()
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runWebServer(ctx, handlers.CreateDebugRouter(), 8080)
+		runWebServer(ctx, handlers.CreateDebugRouter(), debugPort)
 	}()
 
 	wg.Wait()

--- a/server/main.go
+++ b/server/main.go
@@ -54,7 +54,7 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runWebServer(ctx, handlers.CreateRouter(ctx, s), 80)
+		runWebServer(ctx, handlers.CreateRouter(ctx, s), 8008)
 	}()
 
 	wg.Add(1)


### PR DESCRIPTION
Port 80 requires root privs, which is not ideal. Lets use a similar port - i vote for 8008 somewhat arbitrarily. Happy to discuss.

## For External Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/luno/.github/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [ ] If it's a non-trivial change, I've linked a new or existing [issue](../issues) to this PR
- [x] I have performed a self-review of my code
- [x] Does your submission pass existing tests?
- [ ] Have you written new tests for your new changes, if applicable?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
