### PR TITLE
Update to SonarQube scan action

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -22,6 +22,7 @@ jobs:
         run: go test -coverpkg=./... -coverprofile=coverage.out -json ./... > sonar-report.json
 
       - name: Upload coverage reports to Sonar
-        uses: sonarsource/sonarcloud-github-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: github.event.pull_request.head.repo.full_name == github.repository || env.SONAR_TOKEN != ''
+        uses: SonarSource/sonarqube-scan-action@master


### PR DESCRIPTION
This PR replaces the deprecated `sonarsource/sonarcloud-github-action@master` with the recommended `SonarSource/sonarqube-scan-action@master` as suggested in the CI warning message.

The warning message was:
```
echo "::warning title=SonarScanner::This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action."
```

This change follows the same pattern as used in [luno/luno-go](https://github.com/luno/luno-go/blob/main/.github/workflows/sonar.yml), including the conditional check to only run the SonarQube scan when:
- The pull request comes from the same repository (not a fork), or
- The SONAR_TOKEN environment variable is available