### PR TITLE
gomod: Update Go version to 1.24.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/gridlock
 
-go 1.18
+go 1.24.3
 
 require (
 	github.com/gomodule/redigo v1.8.8


### PR DESCRIPTION
## Changed
- Updated `go` directive in go.mod from `go 1.18` to `go 1.24.3`

## Rationale
- Go 1.24.3 is the latest patch release of Go 1.24
- This ensures the project can update to other libraries that declare _their_ minimum version as 1.24
- Aligns with other Luno repositories that are already using Go 1.24.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go module version to 1.24.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->